### PR TITLE
UI polish: zoom-aware time formatting, window title, Cmd+C hint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1307,9 +1307,11 @@ impl eframe::App for MemoryVizApp {
                             );
                         }
                         if is_pinned {
-                            ui.label("| [pinned] Click empty to unpin | Ctrl+C to copy");
+                            let copy_hint = if cfg!(target_os = "macos") { "Cmd+C" } else { "Ctrl+C" };
+                            ui.label(format!("| [pinned] Click empty to unpin | {} to copy", copy_hint));
                         } else {
-                            ui.label("| Click to pin | Ctrl+C to copy");
+                            let copy_hint = if cfg!(target_os = "macos") { "Cmd+C" } else { "Ctrl+C" };
+                            ui.label(format!("| Click to pin | {} to copy", copy_hint));
                         }
                     });
                     if !info.frame_str.is_empty() {
@@ -1324,7 +1326,8 @@ impl eframe::App for MemoryVizApp {
                         });
                     }
                 } else {
-                    ui.label("Hover over an allocation for details. Click=pin, Scroll=zoom X, Shift+Scroll=zoom Y, Drag=pan, Cmd+Drag=select region, Double-click=fit Y, Right-click=dismiss tooltip, Ctrl+C=copy.");
+                    let copy_hint = if cfg!(target_os = "macos") { "Cmd+C" } else { "Ctrl+C" };
+                    ui.label(format!("Hover over an allocation for details. Click=pin, Scroll=zoom X, Shift+Scroll=zoom Y, Drag=pan, Cmd+Drag=select region, Double-click=fit Y, Right-click=dismiss tooltip, {}=copy.", copy_hint));
                 }
             });
 


### PR DESCRIPTION
## Summary
- **Don't show annotation past its end time**: `find_annotation_at` now checks `end_us` so paired annotations aren't shown in tooltips/mode line after they've ended
- **Show snapshot filename in window title**: e.g. "CUDA Memory Timeline — memory_snapshot_gemma27b_compile.pickle"
- **Zoom-aware time formatting on X axis**: Tick labels, tooltips, mode line, and view range all adapt precision to the zoom level (e.g. `4m32.1234s` instead of `4.5m` when zoomed in)
- **Platform-aware copy hint**: Shows "Cmd+C" on macOS, "Ctrl+C" on other platforms

## Test plan
- [ ] Zoom into microsecond scale — X axis ticks should show full precision (e.g. `2m31.4523s`)
- [ ] Tooltips show matching precision when zoomed in
- [ ] Window title shows the input filename
- [ ] Copy hint shows "Cmd+C" on macOS
- [ ] Annotation tooltip disappears when cursor is past a paired annotation's end time

🤖 Generated with [Claude Code](https://claude.com/claude-code)