### PR TITLE
Native Rust pickle parser, baseline visualization, time-window filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +481,21 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
 
 [[package]]
 name = "base64"
@@ -860,11 +884,28 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
+ "dhat",
  "eframe",
  "egui",
  "serde",
  "serde_json",
  "ureq",
+]
+
+[[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
 ]
 
 [[package]]
@@ -1371,6 +1412,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,6 +1826,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,6 +1960,12 @@ dependencies = [
  "adler2",
  "simd-adler32",
 ]
+
+[[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "moxcms"
@@ -2310,6 +2369,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2653,6 +2721,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -3097,6 +3171,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "tiff"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,12 @@ serde_json = "1"
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 ureq = "3"
+dhat = { version = "0.3", optional = true }
+
+[features]
+heap-profile = ["dep:dhat"]
 
 [profile.release]
 opt-level = 3
 lto = true
+debug = "line-tables-only"

--- a/src/bin/extract_pickle.rs
+++ b/src/bin/extract_pickle.rs
@@ -1,0 +1,140 @@
+//! Standalone CLI that parses a PyTorch memory snapshot .pickle (or .pickle.gz)
+//! and writes the same JSON format produced by extract_snapshot.py.
+//!
+//! Usage:
+//!     extract_pickle <input.pickle> <output.json>
+
+use anyhow::{Context, Result};
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Write};
+use std::path::PathBuf;
+use std::time::Instant;
+
+// Share the pickle module with the main binary by path.
+#[path = "../pickle.rs"]
+mod pickle;
+
+#[cfg(feature = "heap-profile")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+fn open_input(path: &PathBuf) -> Result<BufReader<File>> {
+    let f = File::open(path).with_context(|| format!("opening {}", path.display()))?;
+    Ok(BufReader::with_capacity(1 << 20, f))
+}
+
+fn main() -> Result<()> {
+    #[cfg(feature = "heap-profile")]
+    let _profiler = dhat::Profiler::new_heap();
+
+    let mut args = std::env::args_os().skip(1);
+    let input = PathBuf::from(args.next().context("missing <input>")?);
+    let output = PathBuf::from(args.next().context("missing <output>")?);
+    if args.next().is_some() {
+        anyhow::bail!("extra arguments; usage: extract_pickle <input> <output>");
+    }
+
+    let t0 = Instant::now();
+    eprintln!("Parsing {}...", input.display());
+    let rdr = open_input(&input)?;
+    let snap = pickle::parse_snapshot(rdr)?;
+    eprintln!(
+        "  parsed in {:.1}s: {} events, {} unique frames, {} annotations",
+        t0.elapsed().as_secs_f64(),
+        snap.events.len(),
+        snap.frame_strings.len(),
+        snap.annotations.len()
+    );
+
+    eprintln!(
+        "  {} segments-baseline blocks (live before recording, persisted)",
+        snap.live_blocks.len()
+    );
+
+    let t1 = Instant::now();
+    eprintln!("Writing {}...", output.display());
+    let f = File::create(&output).with_context(|| format!("creating {}", output.display()))?;
+    let mut w = BufWriter::with_capacity(1 << 20, f);
+    write_json(&mut w, &snap)?;
+    w.flush()?;
+    eprintln!("  written in {:.1}s", t1.elapsed().as_secs_f64());
+    eprintln!("Total: {:.1}s", t0.elapsed().as_secs_f64());
+    Ok(())
+}
+
+/// Hand-rolled JSON writer that matches extract_snapshot.py's `json.dump(result, f)`
+/// byte-for-byte: default separators ", " and ": ", no trailing newline,
+/// ASCII-safe escaping for non-ASCII codepoints.
+fn write_json<W: Write>(w: &mut W, snap: &pickle::Snapshot) -> Result<()> {
+    w.write_all(b"{\"events\": [")?;
+    for (i, ev) in snap.events.iter().enumerate() {
+        if i > 0 {
+            w.write_all(b", ")?;
+        }
+        write!(w, "[{}, {}, {}, {}, {}]", ev.0, ev.1, ev.2, ev.3, ev.4)?;
+    }
+    w.write_all(b"], \"frame_strings\": [")?;
+    for (i, s) in snap.frame_strings.iter().enumerate() {
+        if i > 0 {
+            w.write_all(b", ")?;
+        }
+        write_json_str(w, s)?;
+    }
+    w.write_all(b"], \"annotations\": [")?;
+    for (i, a) in snap.annotations.iter().enumerate() {
+        if i > 0 {
+            w.write_all(b", ")?;
+        }
+        w.write_all(b"{\"stage\": ")?;
+        write_json_str(w, &a.stage)?;
+        w.write_all(b", \"name\": ")?;
+        write_json_str(w, &a.name)?;
+        write!(w, ", \"time_us\": {}}}", a.time_us)?;
+    }
+    w.write_all(b"], \"live_blocks\": [")?;
+    for (i, &(addr, size)) in snap.live_blocks.iter().enumerate() {
+        if i > 0 {
+            w.write_all(b", ")?;
+        }
+        write!(w, "[{}, {}]", addr, size)?;
+    }
+    w.write_all(b"]}")?;
+    Ok(())
+}
+
+/// Match Python's json.dumps default (ensure_ascii=True): escape control chars
+/// and non-ASCII codepoints with \uXXXX.
+fn write_json_str<W: Write>(w: &mut W, s: &str) -> Result<()> {
+    w.write_all(b"\"")?;
+    for ch in s.chars() {
+        match ch {
+            '"' => w.write_all(b"\\\"")?,
+            '\\' => w.write_all(b"\\\\")?,
+            '\n' => w.write_all(b"\\n")?,
+            '\r' => w.write_all(b"\\r")?,
+            '\t' => w.write_all(b"\\t")?,
+            '\x08' => w.write_all(b"\\b")?,
+            '\x0c' => w.write_all(b"\\f")?,
+            c if (c as u32) < 0x20 => write!(w, "\\u{:04x}", c as u32)?,
+            c if (c as u32) < 0x7f => {
+                let mut buf = [0u8; 4];
+                let s = c.encode_utf8(&mut buf);
+                w.write_all(s.as_bytes())?;
+            }
+            c => {
+                // Non-ASCII: escape as \uXXXX (surrogate pair if > BMP).
+                let cp = c as u32;
+                if cp <= 0xFFFF {
+                    write!(w, "\\u{:04x}", cp)?;
+                } else {
+                    let cp = cp - 0x10000;
+                    let hi = 0xD800 + (cp >> 10);
+                    let lo = 0xDC00 + (cp & 0x3FF);
+                    write!(w, "\\u{:04x}\\u{:04x}", hi, lo)?;
+                }
+            }
+        }
+    }
+    w.write_all(b"\"")?;
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,12 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::Instant;
 
+mod pickle;
+
+#[cfg(feature = "heap-profile")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 // ── CLI ─────────────────────────────────────────────────────────────
 
 /// Native GPU-accelerated CUDA memory snapshot visualizer.
@@ -32,6 +38,13 @@ struct Cli {
     /// Maximum number of allocations to render individually (rest are summarized)
     #[arg(long, default_value = "1000000000")]
     max_entries: usize,
+
+    /// Render each segments-derived static baseline as a separate rect instead
+    /// of collapsing them all into one. Default behavior collapses ~300K
+    /// allocations that were live before recording started into a single
+    /// bottom-band block (with an explanatory tooltip) for performance.
+    #[arg(long, default_value = "false")]
+    no_collapse_static_baselines: bool,
 
     /// HuggingFace model ID (e.g., "google/gemma-2-2b"). Fetches config.json to
     /// get hidden_size and intermediate_size for tensor shape display.
@@ -178,6 +191,11 @@ struct SnapshotJson {
     events: Vec<(u8, u64, u64, i64, u32)>,
     frame_strings: Vec<String>,
     annotations: Vec<JsonAnnotation>,
+    /// (address, size) for blocks live at snapshot time that were never
+    /// alloc'd during the recording. Added by the Rust pickle parser; the
+    /// older Python extractor doesn't write this field.
+    #[serde(default)]
+    live_blocks: Vec<(u64, u64)>,
 }
 
 #[derive(Deserialize)]
@@ -194,6 +212,13 @@ struct AllocRect {
     start_us: i64,
     end_us: i64,
     frame_idx: u32,
+    /// True for rects synthesized from `segments[*].blocks` data — they
+    /// represent allocations that were live before the recording window
+    /// started AND persisted through it. They never participate in the
+    /// polygon-layout shift loop because they never free during the trace,
+    /// which lets `build_polygon_layout` pre-emit them as static bottom-band
+    /// polygons and skip them from the O(n·k) event sweep.
+    is_static_baseline: bool,
 }
 
 // ── Paired annotation ───────────────────────────────────────────────
@@ -206,14 +231,25 @@ struct PairedAnnotation {
 
 // ── Pair alloc/free events into rectangles ──────────────────────────
 
-fn pair_alloc_free(events: &[(u8, u64, u64, i64, u32)], last_time: i64) -> Vec<AllocRect> {
+fn pair_alloc_free(
+    events: &[(u8, u64, u64, i64, u32)],
+    last_time: i64,
+    live_blocks: &[(u64, u64)],
+) -> Vec<AllocRect> {
     let mut live: HashMap<u64, (u64, i64, u32)> = HashMap::new();
     let mut rects: Vec<AllocRect> = Vec::new();
+
+    // Truncated profiles can begin with free events for memory allocated
+    // *before* the recording window. Treat the first free for an unseen
+    // address as if it had been allocated at the trace start.
+    let first_time = events.first().map(|e| e.3).unwrap_or(0);
+    let mut ever_seen: HashSet<u64> = HashSet::new();
 
     for &(action, addr, size, time_us, frame_idx) in events {
         match action {
             0 => {
                 // alloc
+                ever_seen.insert(addr);
                 live.insert(addr, (size, time_us, frame_idx));
             }
             1 | 2 => {
@@ -225,9 +261,24 @@ fn pair_alloc_free(events: &[(u8, u64, u64, i64, u32)], last_time: i64) -> Vec<A
                             start_us,
                             end_us: time_us,
                             frame_idx: alloc_frame,
+                            is_static_baseline: false,
                         });
                     }
+                } else if ever_seen.insert(addr) {
+                    // First time we've ever seen this address and it isn't
+                    // live: it must have been alloc'd before the recording
+                    // window started. Synthesize a baseline rect.
+                    rects.push(AllocRect {
+                        size,
+                        start_us: first_time,
+                        end_us: time_us,
+                        frame_idx,
+                        is_static_baseline: false,
+                    });
                 }
+                // else: redundant free for an addr we've already accounted
+                // for (e.g., the free_completed half of an alloc/free pair,
+                // or a second free for an already-synthesized baseline).
             }
             _ => {
                 // segment events — skip
@@ -242,6 +293,24 @@ fn pair_alloc_free(events: &[(u8, u64, u64, i64, u32)], last_time: i64) -> Vec<A
             start_us,
             end_us: last_time,
             frame_idx,
+            is_static_baseline: false,
+        });
+    }
+
+    // Segments-derived baselines: live before recording started AND still
+    // live at snapshot time. Synthesize a rect spanning the entire trace.
+    // Marked is_static_baseline so build_polygon_layout can pre-emit them
+    // as bottom-band polygons and skip them from the event sweep.
+    for &(_addr, size) in live_blocks {
+        if size == 0 {
+            continue;
+        }
+        rects.push(AllocRect {
+            size,
+            start_us: first_time,
+            end_us: last_time,
+            frame_idx: 0,
+            is_static_baseline: true,
         });
     }
 
@@ -377,10 +446,59 @@ fn convert_pickle_to_json(pickle_path: &PathBuf) -> Result<PathBuf> {
 struct AllocPolygon {
     rect_idx: u32,
     size: u64,
-    /// Parallel arrays: at times_us[i], the y_offset is offsets[i].
-    times_us: Vec<i64>,
-    offsets: Vec<f64>,
+    /// Parallel arrays:
+    /// - `times_us[i]`: i32 packed time relative to the layout's `time_min_us`,
+    ///   in units of 10 µs (multiply by 10 and add base to recover µs).
+    /// - `offsets[i]`: u32 KiB (multiply by 1024 to recover bytes).
+    ///
+    /// Both arrays are quantized to halve the persistent footprint. The
+    /// build pass keeps an exact f64-bytes parallel tracker so that
+    /// repeated shifts don't compound rounding errors in the stored
+    /// offsets. Times are quantized by truncation, which can collapse
+    /// shifts that fall within the same 10 µs bucket — invisible at any
+    /// practical zoom level (10 µs ≪ pixel width).
+    times_us: Vec<i32>,
+    offsets: Vec<u32>,
     color: egui::Color32,
+}
+
+/// Convert a byte offset to the u32-KiB representation used in AllocPolygon.
+#[inline]
+fn offset_bytes_to_kib(bytes: f64) -> u32 {
+    (bytes / 1024.0).round().max(0.0) as u32
+}
+
+/// Convert a stored u32-KiB offset back to bytes (as f64) for rendering or
+/// hover math.
+#[inline]
+fn offset_kib_to_bytes(kib: u32) -> f64 {
+    kib as f64 * 1024.0
+}
+
+/// Number of microseconds per packed time-unit in AllocPolygon.times_us.
+const TIME_QUANTUM_US: i64 = 10;
+
+/// Pack an absolute µs timestamp into the i32 representation used in
+/// AllocPolygon.times_us (10 µs units relative to `base`). Uses round-to-
+/// nearest for evenness.
+#[inline]
+fn time_us_to_packed(t_us: i64, base: i64) -> i32 {
+    let rel = t_us - base;
+    // Round-to-nearest (banker's-style isn't necessary for visual quantization).
+    let half = TIME_QUANTUM_US / 2;
+    let q = if rel >= 0 {
+        (rel + half) / TIME_QUANTUM_US
+    } else {
+        (rel - half) / TIME_QUANTUM_US
+    };
+    q.clamp(i32::MIN as i64, i32::MAX as i64) as i32
+}
+
+/// Unpack an AllocPolygon.times_us entry back to absolute µs as f64 for
+/// rendering math.
+#[inline]
+fn time_packed_to_us_f64(p: i32, base: i64) -> f64 {
+    (base + (p as i64) * TIME_QUANTUM_US) as f64
 }
 
 /// Summarized band for untracked (small) allocations.
@@ -426,29 +544,69 @@ struct PolygonLayout {
 /// 4. On free of tracked: remove, shift all above down by freed size
 /// 5. On alloc/free of untracked: adjust summarized band
 fn build_polygon_layout(
-    rects: Vec<AllocRect>,
-    frame_strings: Vec<String>,
+    mut rects: Vec<AllocRect>,
+    mut frame_strings: Vec<String>,
     annotations: Vec<PairedAnnotation>,
     time_min_us: i64,
     time_max_us: i64,
     total_events: usize,
     max_entries: usize,
+    collapse_static_baselines: bool,
 ) -> PolygonLayout {
+    // Optionally collapse all static-baseline rects into a single merged
+    // rect with an explanatory tooltip. The default is on because there are
+    // typically ~hundreds of thousands of these and rendering them individually
+    // can be slow.
+    if collapse_static_baselines {
+        let mut total_size: u64 = 0;
+        let mut count: usize = 0;
+        for r in &rects {
+            if r.is_static_baseline {
+                total_size = total_size.saturating_add(r.size);
+                count += 1;
+            }
+        }
+        if count > 0 {
+            rects.retain(|r| !r.is_static_baseline);
+            let frame_idx = frame_strings.len() as u32;
+            frame_strings.push(format!(
+                "{} static-baseline allocations (totaling {:.2} GB) collapsed. \
+                 Relaunch with --no-collapse-static-baselines to render individually.",
+                count,
+                total_size as f64 / 1e9
+            ));
+            rects.push(AllocRect {
+                size: total_size,
+                start_us: time_min_us,
+                end_us: time_max_us,
+                frame_idx,
+                is_static_baseline: true,
+            });
+        }
+    }
     let total_rects = rects.len();
 
-    // 1. Select top max_entries allocations by size
+    // 1. Select top max_entries allocations by size. Static-baseline rects
+    //    are ALWAYS tracked (they're cheap: 2 polygon-history entries each
+    //    and they never participate in the shift loop).
     let mut by_size: Vec<(u64, u32)> = rects
         .iter()
         .enumerate()
+        .filter(|(_, r)| !r.is_static_baseline)
         .map(|(i, r)| (r.size, i as u32))
         .collect();
     by_size.sort_unstable_by(|a, b| b.0.cmp(&a.0)); // largest first
 
-    let tracked: HashSet<u32> = by_size
+    let mut tracked: HashSet<u32> = by_size
         .iter()
         .take(max_entries)
         .map(|&(_, idx)| idx)
         .collect();
+    for (i, r) in rects.iter().enumerate() {
+        if r.is_static_baseline {
+            tracked.insert(i as u32);
+        }
+    }
 
     let tracked_count = tracked.len();
     let summarized_count = total_rects - tracked_count;
@@ -457,25 +615,62 @@ fn build_polygon_layout(
         tracked_count, summarized_count
     );
 
-    // 2. Build sorted event list
+    // 2. Pre-emit polygons for static baselines: each is a constant-offset
+    //    rect from first_time to last_time. They stack at the bottom in
+    //    iteration order and never move (nothing below them ever frees).
     let n = rects.len();
+    let mut polygons: Vec<AllocPolygon> = Vec::with_capacity(tracked_count);
+    let mut polygon_map: HashMap<u32, usize> = HashMap::new();
+    let mut rect_to_poly: Vec<u32> = vec![u32::MAX; n];
+    let mut total_mem: f64 = 0.0;
+    // Parallel to `polygons`: stores each polygon's current y-offset in bytes
+    // (f64, exact). The persistent offsets array on AllocPolygon is u32 KiB
+    // (lossy). Keeping an exact byte-precision tracker during the build pass
+    // means each new entry pushed to AllocPolygon.offsets is derived from the
+    // true running total — not from the previously-quantized value — so
+    // rounding errors do NOT compound across shifts.
+    let mut polygon_offset_bytes: Vec<f64> = Vec::with_capacity(tracked_count);
+
+    for (i, r) in rects.iter().enumerate() {
+        if !r.is_static_baseline {
+            continue;
+        }
+        let poly_idx = polygons.len();
+        let kib = offset_bytes_to_kib(total_mem);
+        polygons.push(AllocPolygon {
+            rect_idx: i as u32,
+            size: r.size,
+            times_us: vec![
+                time_us_to_packed(r.start_us, time_min_us),
+                time_us_to_packed(r.end_us, time_min_us),
+            ],
+            offsets: vec![kib, kib],
+            color: alloc_color(i as u32),
+        });
+        polygon_offset_bytes.push(total_mem);
+        polygon_map.insert(i as u32, poly_idx);
+        rect_to_poly[i] = poly_idx as u32;
+        total_mem += r.size as f64;
+    }
+    let static_baseline_offset = total_mem;
+
+    // 3. Build sorted event list ONLY for non-static rects (static baselines
+    //    are already emitted; including them here would put them on `current`
+    //    and force every shift loop to scan past them).
     let mut sorted_events: Vec<(i64, u8, u32)> = Vec::with_capacity(n * 2);
     for (i, r) in rects.iter().enumerate() {
+        if r.is_static_baseline {
+            continue;
+        }
         sorted_events.push((r.start_us, 1, i as u32)); // alloc
         sorted_events.push((r.end_us, 0, i as u32)); // free
     }
-    // Sort by time; at same time, allocs before frees (type 1 > type 0, so reverse)
     sorted_events.sort_unstable_by(|a, b| a.0.cmp(&b.0).then(b.1.cmp(&a.1)));
 
-    // 3. Process events in time order
-    let mut current: Vec<u32> = Vec::new(); // ordered stack of tracked rect_idxs
-    let mut polygon_map: HashMap<u32, usize> = HashMap::new(); // rect_idx -> index in polygons vec
-    let mut polygons: Vec<AllocPolygon> = Vec::with_capacity(tracked_count);
-    let mut rect_to_poly: Vec<u32> = vec![u32::MAX; n];
-
-    let mut total_mem: f64 = 0.0; // sum of tracked live allocations
+    // 4. Process events in time order
+    let mut current: Vec<u32> = Vec::new(); // ordered stack of tracked dynamic rect_idxs
     let mut total_summarized_mem: f64 = 0.0;
-    let mut peak: f64 = 0.0;
+    let mut peak: f64 = static_baseline_offset;
 
     let mut summarized = SummarizedBand {
         times_us: Vec::new(),
@@ -532,10 +727,11 @@ fn build_polygon_layout(
                 polygons.push(AllocPolygon {
                     rect_idx,
                     size: rects[rect_idx as usize].size,
-                    times_us: vec![time_us],
-                    offsets: vec![total_mem],
+                    times_us: vec![time_us_to_packed(time_us, time_min_us)],
+                    offsets: vec![offset_bytes_to_kib(total_mem)],
                     color: alloc_color(rect_idx),
                 });
+                polygon_offset_bytes.push(total_mem);
                 polygon_map.insert(rect_idx, poly_idx);
                 rect_to_poly[rect_idx as usize] = poly_idx as u32;
                 total_mem += size;
@@ -549,11 +745,12 @@ fn build_polygon_layout(
             0 => {
                 // Free: find in current, remove, shift above down
                 if let Some(stack_idx) = current.iter().rposition(|&x| x == rect_idx) {
+                    let packed_t = time_us_to_packed(time_us, time_min_us);
                     // Record final position for freed allocation
                     if let Some(&poly_idx) = polygon_map.get(&rect_idx) {
-                        let last_offset = *polygons[poly_idx].offsets.last().unwrap_or(&0.0);
-                        polygons[poly_idx].times_us.push(time_us);
-                        polygons[poly_idx].offsets.push(last_offset);
+                        let last_bytes = polygon_offset_bytes[poly_idx];
+                        polygons[poly_idx].times_us.push(packed_t);
+                        polygons[poly_idx].offsets.push(offset_bytes_to_kib(last_bytes));
                     }
 
                     current.remove(stack_idx);
@@ -562,14 +759,17 @@ fn build_polygon_layout(
                     for j in stack_idx..current.len() {
                         let above_rect_idx = current[j];
                         if let Some(&poly_idx) = polygon_map.get(&above_rect_idx) {
-                            let last_offset =
-                                *polygons[poly_idx].offsets.last().unwrap_or(&0.0);
+                            // Read exact byte offset (NOT the quantized one)
+                            let last_bytes = polygon_offset_bytes[poly_idx];
+                            let new_bytes = last_bytes - size;
                             // Record old position
-                            polygons[poly_idx].times_us.push(time_us);
-                            polygons[poly_idx].offsets.push(last_offset);
+                            polygons[poly_idx].times_us.push(packed_t);
+                            polygons[poly_idx].offsets.push(offset_bytes_to_kib(last_bytes));
                             // Record new position (shifted down)
-                            polygons[poly_idx].times_us.push(time_us);
-                            polygons[poly_idx].offsets.push(last_offset - size);
+                            polygons[poly_idx].times_us.push(packed_t);
+                            polygons[poly_idx].offsets.push(offset_bytes_to_kib(new_bytes));
+                            // Update the exact tracker
+                            polygon_offset_bytes[poly_idx] = new_bytes;
                         }
                     }
 
@@ -592,11 +792,12 @@ fn build_polygon_layout(
     }
 
     // Finalize: extend all live tracked allocations to end time
+    let packed_end = time_us_to_packed(time_max_us, time_min_us);
     for &rect_idx in &current {
         if let Some(&poly_idx) = polygon_map.get(&rect_idx) {
-            let last_offset = *polygons[poly_idx].offsets.last().unwrap_or(&0.0);
-            polygons[poly_idx].times_us.push(time_max_us);
-            polygons[poly_idx].offsets.push(last_offset);
+            let last_bytes = polygon_offset_bytes[poly_idx];
+            polygons[poly_idx].times_us.push(packed_end);
+            polygons[poly_idx].offsets.push(offset_bytes_to_kib(last_bytes));
         }
     }
     // Final summarized state
@@ -748,6 +949,13 @@ fn build_view_cache(
         };
 
     // Paint each tracked polygon
+    let base_us = layout.time_min_us;
+    // Convert view bounds into packed-time units for cheap comparisons against
+    // the i32 times array.
+    let view_min_packed: i32 = {
+        let q = ((view_x_min_us - base_us as f64) / TIME_QUANTUM_US as f64).floor();
+        q.clamp(i32::MIN as f64, i32::MAX as f64) as i32
+    };
     for poly in &layout.polygons {
         let size = poly.size as f64;
         let times = &poly.times_us;
@@ -757,12 +965,12 @@ fn build_view_cache(
         }
 
         // Binary search for first entry with time >= view_x_min
-        let start_idx = times.partition_point(|&t| (t as f64) < view_x_min_us);
+        let start_idx = times.partition_point(|&t| t < view_min_packed);
         let start_idx = if start_idx > 0 { start_idx - 1 } else { 0 };
 
         for i in start_idx..times.len().saturating_sub(1) {
-            let t0 = times[i] as f64;
-            let t1 = times[i + 1] as f64;
+            let t0 = time_packed_to_us_f64(times[i], base_us);
+            let t1 = time_packed_to_us_f64(times[i + 1], base_us);
 
             if t1 <= view_x_min_us {
                 continue;
@@ -771,7 +979,7 @@ fn build_view_cache(
                 break;
             }
 
-            let offset = offsets[i];
+            let offset = offset_kib_to_bytes(offsets[i]);
             let y_bottom = offset;
             let y_top = offset + size;
 
@@ -2030,17 +2238,20 @@ impl eframe::App for MemoryVizApp {
                         return;
                     }
                     let mut points: Vec<egui::Pos2> = Vec::with_capacity(n * 4);
+                    let base_us = self.layout.time_min_us;
                     for i in 0..n - 1 {
-                        let x0 = us_to_screen_x(poly.times_us[i] as f64);
-                        let x1 = us_to_screen_x(poly.times_us[i + 1] as f64);
-                        let y = bytes_to_screen_y(poly.offsets[i]);
+                        let x0 = us_to_screen_x(time_packed_to_us_f64(poly.times_us[i], base_us));
+                        let x1 =
+                            us_to_screen_x(time_packed_to_us_f64(poly.times_us[i + 1], base_us));
+                        let y = bytes_to_screen_y(offset_kib_to_bytes(poly.offsets[i]));
                         points.push(egui::pos2(x0, y));
                         points.push(egui::pos2(x1, y));
                     }
                     for i in (0..n - 1).rev() {
-                        let x0 = us_to_screen_x(poly.times_us[i + 1] as f64);
-                        let x1 = us_to_screen_x(poly.times_us[i] as f64);
-                        let y = bytes_to_screen_y(poly.offsets[i] + size);
+                        let x0 =
+                            us_to_screen_x(time_packed_to_us_f64(poly.times_us[i + 1], base_us));
+                        let x1 = us_to_screen_x(time_packed_to_us_f64(poly.times_us[i], base_us));
+                        let y = bytes_to_screen_y(offset_kib_to_bytes(poly.offsets[i]) + size);
                         points.push(egui::pos2(x0, y));
                         points.push(egui::pos2(x1, y));
                     }
@@ -2116,17 +2327,28 @@ impl eframe::App for MemoryVizApp {
                                         if poly_idx != u32::MAX {
                                             let poly =
                                                 &self.layout.polygons[poly_idx as usize];
+                                            let base_us = self.layout.time_min_us;
+                                            let hover_packed: i32 = {
+                                                let q = ((hover_us - base_us as f64)
+                                                    / TIME_QUANTUM_US as f64)
+                                                    .floor();
+                                                q.clamp(i32::MIN as f64, i32::MAX as f64) as i32
+                                            };
                                             let time_idx = poly
                                                 .times_us
-                                                .partition_point(|&t| (t as f64) <= hover_us);
+                                                .partition_point(|&t| t <= hover_packed);
                                             let seg_idx = if time_idx > 0 {
                                                 time_idx - 1
                                             } else {
                                                 0
                                             };
-                                            let offset = poly.offsets[seg_idx] as u64;
-                                            let last_offset = *poly.offsets.last().unwrap_or(&0.0);
-                                            let dealloc_total = (last_offset + r.size as f64) as u64;
+                                            let offset =
+                                                offset_kib_to_bytes(poly.offsets[seg_idx]) as u64;
+                                            let last_offset = offset_kib_to_bytes(
+                                                *poly.offsets.last().unwrap_or(&0),
+                                            );
+                                            let dealloc_total =
+                                                (last_offset + r.size as f64) as u64;
                                             (offset, dealloc_total)
                                         } else {
                                             (0, 0)
@@ -2548,6 +2770,9 @@ fn format_count(n: usize) -> String {
 // ── Main ────────────────────────────────────────────────────────────
 
 fn main() -> Result<()> {
+    #[cfg(feature = "heap-profile")]
+    let _profiler = dhat::Profiler::new_heap();
+
     let cli = Cli::parse();
     let start = Instant::now();
 
@@ -2601,7 +2826,7 @@ fn main() -> Result<()> {
     // Pair alloc/free events
     eprintln!("Pairing alloc/free events...");
     let t_pair = Instant::now();
-    let rects = pair_alloc_free(&events, time_max);
+    let rects = pair_alloc_free(&events, time_max, &snapshot.live_blocks);
     eprintln!(
         "  {} allocation rectangles in {:.1}s",
         rects.len(),
@@ -2630,6 +2855,7 @@ fn main() -> Result<()> {
         time_max,
         total_events,
         cli.max_entries,
+        !cli.no_collapse_static_baselines,
     );
     eprintln!(
         "  Layout built in {:.1}s",
@@ -2640,6 +2866,19 @@ fn main() -> Result<()> {
         "Total data loading: {:.1}s. Launching GUI...",
         start.elapsed().as_secs_f64()
     );
+
+    #[cfg(feature = "heap-profile")]
+    {
+        // Exit before run_native so the dhat snapshot captures the post-layout
+        // heap state without GUI rendering allocations mixed in. Layout is
+        // still live at this point — it will be dropped at function return,
+        // after the dhat Profiler's Drop writes dhat-heap.json.
+        eprintln!(
+            "[heap-profile] polygons={} | exiting before GUI to dump dhat snapshot",
+            layout.polygons.len()
+        );
+        return Ok(());
+    }
 
     // Launch the egui window
     let icon = eframe::icon_data::from_png_bytes(include_bytes!("../assets/icon.png"))
@@ -2684,4 +2923,98 @@ fn main() -> Result<()> {
     .map_err(|e| anyhow::anyhow!("eframe error: {}", e))?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn baseline_alloc_synthesized_for_pre_window_frees() {
+        // Trace: free for addr 0xA (no prior alloc) + normal alloc/free for addr 0xB.
+        // (action 0=alloc, 1=free_requested, 2=free_completed)
+        let events: Vec<(u8, u64, u64, i64, u32)> = vec![
+            // first event is a free_completed for 0xA — baseline
+            (2, 0xA, 360_192, 100, 7),
+            // normal: alloc + free pair for 0xB
+            (0, 0xB, 512, 110, 3),
+            (1, 0xB, 512, 200, 3),
+            // a free for an addr we already accounted for as baseline:
+            // free_requested followed by free_completed in some real traces.
+            // Only the first free for 0xA should synthesize a rect; the
+            // second should be ignored.
+            (1, 0xA, 360_192, 250, 7),
+        ];
+        let rects = pair_alloc_free(&events, 1000, &[]);
+        // Expect: one baseline rect for 0xA (starts at first_time=100, ends at 100 — the free's time)
+        // plus one normal rect for 0xB.
+        let baseline_rects: Vec<_> = rects.iter().filter(|r| r.start_us == 100).collect();
+        let normal_rects: Vec<_> = rects.iter().filter(|r| r.start_us != 100).collect();
+        // Note: the FIRST free for 0xA is the very first event, so its time_us
+        // equals first_time; the rect would have zero width. Verify count:
+        assert_eq!(baseline_rects.len(), 1, "expected exactly one baseline rect");
+        assert_eq!(baseline_rects[0].size, 360_192);
+        assert_eq!(baseline_rects[0].frame_idx, 7);
+        // The normal alloc/free pair produces one rect.
+        let normal_rect = normal_rects
+            .iter()
+            .find(|r| r.size == 512)
+            .expect("missing normal rect");
+        assert_eq!(normal_rect.start_us, 110);
+        assert_eq!(normal_rect.end_us, 200);
+    }
+
+    #[test]
+    fn second_free_for_same_baseline_addr_does_not_double_count() {
+        // free_requested then free_completed for the SAME pre-window addr.
+        // Only one baseline rect should be synthesized.
+        let events: Vec<(u8, u64, u64, i64, u32)> = vec![
+            (1, 0xC, 1024, 100, 0), // free_requested
+            (2, 0xC, 1024, 101, 0), // free_completed — must NOT create another rect
+        ];
+        let rects = pair_alloc_free(&events, 1000, &[]);
+        assert_eq!(rects.len(), 1, "expected exactly one rect for the addr");
+        assert_eq!(rects[0].size, 1024);
+    }
+
+    #[test]
+    fn live_blocks_produce_full_trace_baseline_rects() {
+        // live_blocks represents allocations that pre-dated the recording
+        // window AND persisted throughout. Synthesize a rect spanning
+        // (first_time, last_time) for each.
+        let events: Vec<(u8, u64, u64, i64, u32)> = vec![
+            (0, 0xE, 4096, 100, 0), // one in-window alloc
+            (1, 0xE, 4096, 200, 0),
+        ];
+        let live_blocks = vec![(0xF000_u64, 1024_u64), (0xF400_u64, 2048_u64)];
+        let rects = pair_alloc_free(&events, 999, &live_blocks);
+        // Expect 1 normal rect + 2 live_blocks rects = 3 total.
+        assert_eq!(rects.len(), 3, "expected 1 in-window + 2 live_blocks rects");
+        let baselines: Vec<_> = rects
+            .iter()
+            .filter(|r| r.start_us == 100 && r.end_us == 999)
+            .collect();
+        assert_eq!(baselines.len(), 2);
+        let total_baseline: u64 = baselines.iter().map(|r| r.size).sum();
+        assert_eq!(total_baseline, 1024 + 2048);
+    }
+
+    #[test]
+    fn normal_alloc_free_pair_does_not_spuriously_create_baseline() {
+        // Bug we fixed: free_completed after a successful free_requested
+        // used to fall into the baseline branch and create a spurious rect.
+        let events: Vec<(u8, u64, u64, i64, u32)> = vec![
+            (0, 0xD, 2048, 50, 0),  // alloc
+            (1, 0xD, 2048, 100, 0), // free_requested — creates the one rect
+            (2, 0xD, 2048, 101, 0), // free_completed — must NOT create another
+        ];
+        let rects = pair_alloc_free(&events, 1000, &[]);
+        assert_eq!(
+            rects.len(),
+            1,
+            "alloc/free_requested/free_completed should produce exactly one rect"
+        );
+        assert_eq!(rects[0].start_us, 50);
+        assert_eq!(rects[0].end_us, 100);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,19 @@ struct Cli {
     #[arg(long, default_value = "false")]
     no_collapse_static_baselines: bool,
 
+    /// Only load events whose time_us is within this window, in seconds
+    /// from the trace's first event. Pair with --max-entries to render
+    /// every rect in a narrow window individually (e.g.
+    /// `--time-start-sec 12.5 --time-end-sec 13.5 --max-entries 1000000000`).
+    /// Annotations are clipped to the window; segments-derived `live_blocks`
+    /// are dropped when a window is set (they describe end-of-trace state).
+    #[arg(long)]
+    time_start_sec: Option<f64>,
+
+    /// See --time-start-sec.
+    #[arg(long)]
+    time_end_sec: Option<f64>,
+
     /// HuggingFace model ID (e.g., "google/gemma-2-2b"). Fetches config.json to
     /// get hidden_size and intermediate_size for tensor shape display.
     #[arg(long)]
@@ -2820,13 +2833,42 @@ fn main() -> Result<()> {
     let mut events = snapshot.events;
     events.sort_by_key(|e| e.3);
 
+    // Optional time-window filter. Events are kept only if their time_us
+    // falls in [trace_start + start_sec, trace_start + end_sec]. Annotations
+    // are clipped to the same window. live_blocks are dropped when a window
+    // is set (they describe state at the original snapshot's end, which is
+    // outside the window).
+    let mut annotations_raw = snapshot.annotations;
+    let mut live_blocks = snapshot.live_blocks;
+    if cli.time_start_sec.is_some() || cli.time_end_sec.is_some() {
+        let trace_start = events.first().map(|e| e.3).unwrap_or(0);
+        let lo = cli
+            .time_start_sec
+            .map(|s| trace_start + (s * 1e6) as i64)
+            .unwrap_or(i64::MIN);
+        let hi = cli
+            .time_end_sec
+            .map(|s| trace_start + (s * 1e6) as i64)
+            .unwrap_or(i64::MAX);
+        let before = events.len();
+        events.retain(|e| e.3 >= lo && e.3 <= hi);
+        annotations_raw.retain(|a| a.time_us >= lo && a.time_us <= hi);
+        live_blocks.clear();
+        eprintln!(
+            "  time-window filter: kept {} of {} events ({} ann)",
+            events.len(),
+            before,
+            annotations_raw.len()
+        );
+    }
+
     let time_min = events.first().map(|e| e.3).unwrap_or(0);
     let time_max = events.last().map(|e| e.3).unwrap_or(0);
 
     // Pair alloc/free events
     eprintln!("Pairing alloc/free events...");
     let t_pair = Instant::now();
-    let rects = pair_alloc_free(&events, time_max, &snapshot.live_blocks);
+    let rects = pair_alloc_free(&events, time_max, &live_blocks);
     eprintln!(
         "  {} allocation rectangles in {:.1}s",
         rects.len(),
@@ -2835,7 +2877,7 @@ fn main() -> Result<()> {
 
     // Pair annotations
     let annotations = pair_annotations(
-        &snapshot.annotations,
+        &annotations_raw,
         &cli.annotation_filter,
         cli.all_annotations,
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -538,9 +538,16 @@ struct PolygonLayout {
     frame_strings: Vec<String>,
     /// Paired annotations.
     annotations: Vec<PairedAnnotation>,
-    /// Time range in microseconds.
+    /// Time range in microseconds (of the events that were actually loaded,
+    /// i.e. post-filter).
     time_min_us: i64,
     time_max_us: i64,
+    /// Origin used for axis-label display: the time_us of the first event in
+    /// the *original* trace, before any --time-start-sec window was applied.
+    /// Equals `time_min_us` when no window is active. Labels are computed as
+    /// `(val - display_origin_us) / 1e6` so that a filtered view at 12.5s
+    /// shows "12.5s" at the left edge rather than "0s".
+    display_origin_us: i64,
     /// Peak total memory (tracked + summarized).
     peak_bytes: u64,
     /// Stats.
@@ -562,6 +569,7 @@ fn build_polygon_layout(
     annotations: Vec<PairedAnnotation>,
     time_min_us: i64,
     time_max_us: i64,
+    display_origin_us: i64,
     total_events: usize,
     max_entries: usize,
     collapse_static_baselines: bool,
@@ -836,6 +844,7 @@ fn build_polygon_layout(
         annotations,
         time_min_us,
         time_max_us,
+        display_origin_us,
         peak_bytes: peak as u64,
         total_events,
         total_rects,
@@ -1884,8 +1893,8 @@ impl eframe::App for MemoryVizApp {
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     ui.label(format!(
                         "View: {} - {} | {} - {}",
-                        Self::format_axis_time_us(self.view_x_min_us - self.layout.time_min_us as f64, (self.view_x_max_us - self.view_x_min_us) / 10.0),
-                        Self::format_axis_time_us(self.view_x_max_us - self.layout.time_min_us as f64, (self.view_x_max_us - self.view_x_min_us) / 10.0),
+                        Self::format_axis_time_us(self.view_x_min_us - self.layout.display_origin_us as f64, (self.view_x_max_us - self.view_x_min_us) / 10.0),
+                        Self::format_axis_time_us(self.view_x_max_us - self.layout.display_origin_us as f64, (self.view_x_max_us - self.view_x_min_us) / 10.0),
                         Self::format_bytes(self.view_y_min_bytes + self.memory_offset_bytes),
                         Self::format_bytes(self.view_y_max_bytes + self.memory_offset_bytes),
                     ));
@@ -1911,7 +1920,7 @@ impl eframe::App for MemoryVizApp {
         let shape_str = bottom_info
             .as_ref()
             .and_then(|info| self.format_tensor_shape(info.size_bytes));
-        let time_min_us = self.layout.time_min_us as f64;
+        let time_min_us = self.layout.display_origin_us as f64;
 
         egui::TopBottomPanel::bottom("hover_info")
             .exact_height(100.0)
@@ -2077,7 +2086,7 @@ impl eframe::App for MemoryVizApp {
                     egui::Stroke::new(0.5, grid_color),
                 );
                 let val = vx_min + frac as f64 * x_range;
-                let relative = val - self.layout.time_min_us as f64;
+                let relative = val - self.layout.display_origin_us as f64;
                 painter.text(
                     egui::pos2(x, chart_rect.max.y + 6.0),
                     egui::Align2::CENTER_TOP,
@@ -2417,11 +2426,11 @@ impl eframe::App for MemoryVizApp {
                             ui.label(format!(
                                 "Time: {} - {}",
                                 Self::format_axis_time_us(
-                                    info.start_us as f64 - self.layout.time_min_us as f64,
+                                    info.start_us as f64 - self.layout.display_origin_us as f64,
                                     tick_sp,
                                 ),
                                 Self::format_axis_time_us(
-                                    info.end_us as f64 - self.layout.time_min_us as f64,
+                                    info.end_us as f64 - self.layout.display_origin_us as f64,
                                     tick_sp,
                                 ),
                             ));
@@ -2455,7 +2464,7 @@ impl eframe::App for MemoryVizApp {
                             }
                         });
                     } else if !self.tooltip_dismissed {
-                        let rel_us = hover_us - self.layout.time_min_us as f64;
+                        let rel_us = hover_us - self.layout.display_origin_us as f64;
                         egui::show_tooltip_at_pointer(ctx, response.layer_id, egui::Id::new("cursor_tooltip"), |ui| {
                             ui.label(format!(
                                 "t = {} | mem = {}",
@@ -2658,7 +2667,7 @@ impl eframe::App for MemoryVizApp {
                 Self::draw_ruler(&painter, ruler, &bytes_to_screen_y, &us_to_screen_x, chart_rect, self.memory_offset_bytes);
             }
             if let Some(ref hruler) = self.hruler {
-                Self::draw_hruler(&painter, hruler, &bytes_to_screen_y, &us_to_screen_x, chart_rect, self.layout.time_min_us as f64);
+                Self::draw_hruler(&painter, hruler, &bytes_to_screen_y, &us_to_screen_x, chart_rect, self.layout.display_origin_us as f64);
             }
 
             // Dismiss rulers with Escape
@@ -2840,8 +2849,12 @@ fn main() -> Result<()> {
     // outside the window).
     let mut annotations_raw = snapshot.annotations;
     let mut live_blocks = snapshot.live_blocks;
+    // Capture the original trace's first event time BEFORE any filtering, so
+    // axis labels remain anchored to it (a windowed view at 12.5s shows
+    // "12.5s" at the left edge instead of "0s").
+    let original_trace_start = events.first().map(|e| e.3).unwrap_or(0);
     if cli.time_start_sec.is_some() || cli.time_end_sec.is_some() {
-        let trace_start = events.first().map(|e| e.3).unwrap_or(0);
+        let trace_start = original_trace_start;
         let lo = cli
             .time_start_sec
             .map(|s| trace_start + (s * 1e6) as i64)
@@ -2851,14 +2864,44 @@ fn main() -> Result<()> {
             .map(|s| trace_start + (s * 1e6) as i64)
             .unwrap_or(i64::MAX);
         let before = events.len();
+
+        // Pre-pass: walk events strictly before `lo` to find allocations
+        // that were live at the start of the window (alloc'd but not yet
+        // freed). Feed them into `live_blocks` so they're rendered via the
+        // segments-style static-baseline path (a single collapsed bottom
+        // block by default, optionally per-rect via
+        // --no-collapse-static-baselines). This trades baseline detail
+        // (we no longer show baseline frees within the window) for
+        // dramatically less work in build_polygon_layout.
+        let mut live_at_start: HashMap<u64, u64> = HashMap::new();
+        for &(action, addr, size, time_us, _frame_idx) in events.iter() {
+            if time_us >= lo {
+                break;
+            }
+            match action {
+                0 => {
+                    live_at_start.insert(addr, size);
+                }
+                1 | 2 => {
+                    live_at_start.remove(&addr);
+                }
+                _ => {}
+            }
+        }
+
         events.retain(|e| e.3 >= lo && e.3 <= hi);
         annotations_raw.retain(|a| a.time_us >= lo && a.time_us <= hi);
         live_blocks.clear();
+        let n_baselines = live_at_start.len();
+        for (addr, size) in live_at_start {
+            live_blocks.push((addr, size));
+        }
         eprintln!(
-            "  time-window filter: kept {} of {} events ({} ann)",
+            "  time-window filter: kept {} of {} events ({} ann); {} live-at-window-start allocs added as static baselines",
             events.len(),
             before,
-            annotations_raw.len()
+            annotations_raw.len(),
+            n_baselines,
         );
     }
 
@@ -2895,6 +2938,7 @@ fn main() -> Result<()> {
         annotations,
         time_min,
         time_max,
+        original_trace_start,
         total_events,
         cli.max_entries,
         !cli.no_collapse_static_baselines,

--- a/src/pickle.rs
+++ b/src/pickle.rs
@@ -1,0 +1,806 @@
+//! Streaming pickle parser specialized for PyTorch memory snapshots.
+//!
+//! Supports the subset of pickle protocol 4 opcodes observed in
+//! torch.cuda.memory._dump_snapshot output. Recognizes event and annotation
+//! dicts at SETITEMS time, extracts their fields into a `Snapshot`, and
+//! discards the dict immediately (stack slot + memo slot) so the heap is
+//! freed instead of accumulating ~31M dicts in memory.
+
+use anyhow::{bail, Context, Result};
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
+use std::io::Read;
+use std::rc::Rc;
+
+// ── Opcode constants (pickle protocol 4 subset) ─────────────────────────
+
+const PROTO: u8 = 0x80;
+const FRAME: u8 = 0x95;
+const STOP: u8 = b'.';
+
+const EMPTY_DICT: u8 = b'}';
+const EMPTY_LIST: u8 = b']';
+const EMPTY_TUPLE: u8 = b')';
+const MARK: u8 = b'(';
+
+const SETITEM: u8 = b's';
+const SETITEMS: u8 = b'u';
+const APPEND: u8 = b'a';
+const APPENDS: u8 = b'e';
+
+const TUPLE: u8 = b't';
+const TUPLE1: u8 = 0x85;
+const TUPLE2: u8 = 0x86;
+const TUPLE3: u8 = 0x87;
+
+const MEMOIZE: u8 = 0x94;
+const BINPUT: u8 = b'q';
+const LONG_BINPUT: u8 = b'r';
+const BINGET: u8 = b'h';
+const LONG_BINGET: u8 = b'j';
+
+const SHORT_BINUNICODE: u8 = 0x8c;
+const BINUNICODE: u8 = b'X';
+const BINUNICODE8: u8 = 0x8d;
+
+const SHORT_BINBYTES: u8 = b'C';
+const BINBYTES: u8 = b'B';
+const BINBYTES8: u8 = 0x8e;
+
+const BININT: u8 = b'J';
+const BININT1: u8 = b'K';
+const BININT2: u8 = b'M';
+const LONG1: u8 = 0x8a;
+const LONG4: u8 = 0x8b;
+
+const BINFLOAT: u8 = b'G';
+
+const NONE_OP: u8 = b'N';
+const NEWTRUE: u8 = 0x88;
+const NEWFALSE: u8 = 0x89;
+
+// ── Value ───────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub struct DictInner {
+    pub pairs: Vec<(Value, Value)>,
+    /// Memo position assigned to this dict by MEMOIZE, if any.
+    /// Used by the event/annotation specialization to release the memo
+    /// slot when the dict has been consumed.
+    pub memo_id: Option<u32>,
+}
+
+#[derive(Clone, Debug)]
+pub enum Value {
+    None,
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    Str(Rc<str>),
+    Bytes(Rc<[u8]>),
+    Tuple(Rc<[Value]>),
+    List(Rc<RefCell<Vec<Value>>>),
+    Dict(Rc<RefCell<DictInner>>),
+    /// Stack-only sentinel for MARK opcode.
+    Mark,
+    /// Placeholder left behind after an event/annotation dict has been
+    /// extracted and dropped. If BINGET ever resolves to this, the
+    /// "discard events" optimization is unsafe for this snapshot and
+    /// parsing bails with a clear error.
+    Consumed,
+}
+
+// ── Snapshot output ─────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub struct Annotation {
+    pub stage: String,
+    pub name: String,
+    pub time_us: i64,
+}
+
+#[derive(Debug, Default)]
+pub struct Snapshot {
+    /// (action_code, addr, size, time_us, frame_idx)
+    pub events: Vec<(u8, u64, u64, i64, u32)>,
+    pub frame_strings: Vec<String>,
+    pub annotations: Vec<Annotation>,
+    /// (address, size) for blocks live at snapshot time whose address was
+    /// never seen as an alloc in `events`. These represent allocations that
+    /// existed before the recording window started and persisted through it.
+    pub live_blocks: Vec<(u64, u64)>,
+}
+
+fn action_code(s: &str) -> Option<u8> {
+    match s {
+        "alloc" => Some(0),
+        "free_requested" => Some(1),
+        "free_completed" => Some(2),
+        "segment_alloc" => Some(3),
+        "segment_free" => Some(4),
+        "segment_map" => Some(5),
+        "segment_unmap" => Some(6),
+        _ => None,
+    }
+}
+
+// ── Parser ──────────────────────────────────────────────────────────────
+
+pub struct Parser<R: Read> {
+    rdr: R,
+    stack: Vec<Value>,
+    memo: Vec<Value>,
+    out: Snapshot,
+    /// Maps frame-list Rc identity (by pointer) to interned frame_strings index,
+    /// so events sharing the same frames-list Rc skip recomputing frame_summary.
+    frame_cache: HashMap<*const RefCell<Vec<Value>>, u32>,
+    /// Frame-summary string → interned index in out.frame_strings.
+    frame_intern: HashMap<String, u32>,
+    /// Addresses that appeared as `alloc` events. Used at STOP to identify
+    /// segment blocks whose addr was never alloc'd during the window (i.e.
+    /// allocations that pre-dated the recording).
+    alloced_addrs: HashSet<u64>,
+}
+
+impl<R: Read> Parser<R> {
+    pub fn new(rdr: R) -> Self {
+        Self {
+            rdr,
+            stack: Vec::with_capacity(64),
+            memo: Vec::with_capacity(1 << 20),
+            out: Snapshot::default(),
+            frame_cache: HashMap::new(),
+            frame_intern: HashMap::new(),
+            alloced_addrs: HashSet::new(),
+        }
+    }
+
+    // ── Reader helpers ───────────────────────────────────────────────
+
+    fn read_u8(&mut self) -> Result<u8> {
+        let mut b = [0u8; 1];
+        self.rdr.read_exact(&mut b).context("read_u8")?;
+        Ok(b[0])
+    }
+    fn read_u16_le(&mut self) -> Result<u16> {
+        let mut b = [0u8; 2];
+        self.rdr.read_exact(&mut b).context("read_u16_le")?;
+        Ok(u16::from_le_bytes(b))
+    }
+    fn read_i32_le(&mut self) -> Result<i32> {
+        let mut b = [0u8; 4];
+        self.rdr.read_exact(&mut b).context("read_i32_le")?;
+        Ok(i32::from_le_bytes(b))
+    }
+    fn read_u32_le(&mut self) -> Result<u32> {
+        let mut b = [0u8; 4];
+        self.rdr.read_exact(&mut b).context("read_u32_le")?;
+        Ok(u32::from_le_bytes(b))
+    }
+    fn read_u64_le(&mut self) -> Result<u64> {
+        let mut b = [0u8; 8];
+        self.rdr.read_exact(&mut b).context("read_u64_le")?;
+        Ok(u64::from_le_bytes(b))
+    }
+    fn read_n(&mut self, n: usize) -> Result<Vec<u8>> {
+        let mut buf = vec![0u8; n];
+        self.rdr.read_exact(&mut buf).context("read_n")?;
+        Ok(buf)
+    }
+    fn read_str(&mut self, n: usize) -> Result<Rc<str>> {
+        let buf = self.read_n(n)?;
+        let s = std::str::from_utf8(&buf).context("invalid utf-8 in pickle string")?;
+        Ok(Rc::from(s))
+    }
+
+    fn pop(&mut self) -> Result<Value> {
+        self.stack.pop().context("pickle stack underflow")
+    }
+    fn find_mark(&self) -> Result<usize> {
+        for (i, v) in self.stack.iter().enumerate().rev() {
+            if matches!(v, Value::Mark) {
+                return Ok(i);
+            }
+        }
+        bail!("no MARK on stack")
+    }
+    fn drain_to_mark(&mut self) -> Result<Vec<Value>> {
+        let idx = self.find_mark()?;
+        let items: Vec<Value> = self.stack.drain(idx + 1..).collect();
+        self.stack.pop(); // remove MARK
+        Ok(items)
+    }
+
+    // ── Memo ─────────────────────────────────────────────────────────
+
+    fn memo_put(&mut self, idx: usize) -> Result<()> {
+        // Tag the dict with its memo id so SETITEMS can clear the slot
+        // after extracting an event/annotation dict.
+        if let Some(Value::Dict(d)) = self.stack.last() {
+            let mut dref = d.borrow_mut();
+            if dref.memo_id.is_none() {
+                dref.memo_id = Some(idx as u32);
+            }
+        }
+        let v = self
+            .stack
+            .last()
+            .context("memo put on empty stack")?
+            .clone();
+        if idx >= self.memo.len() {
+            self.memo.resize(idx + 1, Value::None);
+        }
+        self.memo[idx] = v;
+        Ok(())
+    }
+
+    fn memo_get(&mut self, idx: usize) -> Result<()> {
+        let v = self
+            .memo
+            .get(idx)
+            .with_context(|| format!("memo get out of range: {}", idx))?
+            .clone();
+        if matches!(v, Value::Consumed) {
+            bail!(
+                "memo slot {} resolves to a consumed event/annotation dict; \
+                 this snapshot uses BINGET on event-shell dicts and the \
+                 'discard events on SETITEMS' optimization is unsafe for it",
+                idx
+            );
+        }
+        self.stack.push(v);
+        Ok(())
+    }
+
+    // ── Event / annotation specialization ─────────────────────────────
+
+    /// If `pairs` looks like an event or annotation dict, extract the fields
+    /// into self.out and return true. Otherwise return false (caller leaves
+    /// the dict on the stack as a normal Value::Dict).
+    fn try_emit_specialized(&mut self, pairs: &[(Value, Value)]) -> bool {
+        // First scan: find action and stage values.
+        let mut action: Option<Rc<str>> = None;
+        let mut stage: Option<Rc<str>> = None;
+        for (k, v) in pairs {
+            let Value::Str(k) = k else { continue };
+            match &**k {
+                "action" => {
+                    if let Value::Str(s) = v {
+                        action = Some(s.clone());
+                    }
+                }
+                "stage" => {
+                    if let Value::Str(s) = v {
+                        stage = Some(s.clone());
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if let Some(act) = action {
+            // Event dict.
+            let Some(code) = action_code(&act) else {
+                // Unknown action: match Python (skip event) but still consume
+                // the dict so we can free it.
+                return true;
+            };
+            let mut addr: u64 = 0;
+            let mut size: u64 = 0;
+            let mut time_us: i64 = 0;
+            let mut frames_ref: Option<Rc<RefCell<Vec<Value>>>> = None;
+            for (k, v) in pairs {
+                let Value::Str(k) = k else { continue };
+                match &**k {
+                    "addr" => {
+                        if let Value::Int(i) = v {
+                            addr = *i as u64;
+                        }
+                    }
+                    "size" => {
+                        if let Value::Int(i) = v {
+                            size = *i as u64;
+                        }
+                    }
+                    "time_us" => {
+                        if let Value::Int(i) = v {
+                            time_us = *i;
+                        }
+                    }
+                    "frames" => {
+                        if let Value::List(l) = v {
+                            frames_ref = Some(l.clone());
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            let frame_idx = self.intern_frames(frames_ref);
+            self.out.events.push((code, addr, size, time_us, frame_idx));
+            // Track addrs that appeared as `alloc` (code 0) for later
+            // segments-baseline matching.
+            if code == 0 {
+                self.alloced_addrs.insert(addr);
+            }
+            return true;
+        }
+
+        if let Some(stage) = stage {
+            // Annotation dict: require a "time_us" key to disambiguate.
+            let mut name = String::new();
+            let mut time_us: i64 = 0;
+            let mut has_time = false;
+            for (k, v) in pairs {
+                let Value::Str(k) = k else { continue };
+                match &**k {
+                    "name" => {
+                        if let Value::Str(s) = v {
+                            name = s.to_string();
+                        }
+                    }
+                    "time_us" => {
+                        if let Value::Int(i) = v {
+                            time_us = *i;
+                            has_time = true;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            if has_time {
+                self.out.annotations.push(Annotation {
+                    stage: stage.to_string(),
+                    name,
+                    time_us,
+                });
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Intern a frame_summary string, using the Rc-identity cache to skip the
+    /// O(frames) walk when this exact frames Rc has been seen before.
+    fn intern_frames(&mut self, frames: Option<Rc<RefCell<Vec<Value>>>>) -> u32 {
+        let Some(frames_rc) = frames else {
+            return self.intern_str(String::new());
+        };
+        let key = Rc::as_ptr(&frames_rc);
+        if let Some(&idx) = self.frame_cache.get(&key) {
+            return idx;
+        }
+        let summary = frame_summary(&frames_rc.borrow());
+        let idx = self.intern_str(summary);
+        self.frame_cache.insert(key, idx);
+        idx
+    }
+
+    fn intern_str(&mut self, s: String) -> u32 {
+        if let Some(&i) = self.frame_intern.get(&s) {
+            return i;
+        }
+        let i = self.out.frame_strings.len() as u32;
+        self.frame_intern.insert(s.clone(), i);
+        self.out.frame_strings.push(s);
+        i
+    }
+
+    /// Walk the top-level dict's `segments[*].blocks` and record blocks whose
+    /// address never appeared as an `alloc` event during the trace. These are
+    /// allocations that pre-dated the recording window and persisted through
+    /// it; they're not visible in the event stream alone.
+    fn collect_live_blocks(&mut self, root: &Value) {
+        let Value::Dict(top) = root else { return };
+        let top = top.borrow();
+        let mut segments_val: Option<Value> = None;
+        for (k, v) in &top.pairs {
+            if let Value::Str(k) = k {
+                if &**k == "segments" {
+                    segments_val = Some(v.clone());
+                    break;
+                }
+            }
+        }
+        let Some(Value::List(segments)) = segments_val else {
+            return;
+        };
+        for seg in segments.borrow().iter() {
+            let Value::Dict(seg) = seg else { continue };
+            let seg = seg.borrow();
+            // Find blocks
+            let mut blocks_val: Option<Value> = None;
+            for (k, v) in &seg.pairs {
+                if let Value::Str(k) = k {
+                    if &**k == "blocks" {
+                        blocks_val = Some(v.clone());
+                        break;
+                    }
+                }
+            }
+            let Some(Value::List(blocks)) = blocks_val else {
+                continue;
+            };
+            for blk in blocks.borrow().iter() {
+                let Value::Dict(blk) = blk else { continue };
+                let blk = blk.borrow();
+                let mut addr: u64 = 0;
+                let mut size: u64 = 0;
+                let mut state_active = false;
+                for (k, v) in &blk.pairs {
+                    let Value::Str(k) = k else { continue };
+                    match &**k {
+                        "address" => {
+                            if let Value::Int(i) = v {
+                                addr = *i as u64;
+                            }
+                        }
+                        "size" => {
+                            if let Value::Int(i) = v {
+                                size = *i as u64;
+                            }
+                        }
+                        "state" => {
+                            if let Value::Str(s) = v {
+                                if &**s == "active_allocated" {
+                                    state_active = true;
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                if state_active && !self.alloced_addrs.contains(&addr) {
+                    self.out.live_blocks.push((addr, size));
+                }
+            }
+        }
+    }
+
+    // ── Main parse loop ──────────────────────────────────────────────
+
+    pub fn parse(mut self) -> Result<Snapshot> {
+        loop {
+            let op = self.read_u8()?;
+            match op {
+                PROTO => {
+                    let _v = self.read_u8()?;
+                }
+                FRAME => {
+                    let _len = self.read_u64_le()?;
+                }
+                STOP => {
+                    let root = self.pop()?;
+                    self.collect_live_blocks(&root);
+                    return Ok(self.out);
+                }
+
+                EMPTY_DICT => self.stack.push(Value::Dict(Rc::new(RefCell::new(
+                    DictInner {
+                        pairs: Vec::new(),
+                        memo_id: None,
+                    },
+                )))),
+                EMPTY_LIST => self
+                    .stack
+                    .push(Value::List(Rc::new(RefCell::new(Vec::new())))),
+                EMPTY_TUPLE => self.stack.push(Value::Tuple(Rc::new([]))),
+                MARK => self.stack.push(Value::Mark),
+
+                SETITEM => {
+                    let v = self.pop()?;
+                    let k = self.pop()?;
+                    match self.stack.last() {
+                        Some(Value::Dict(d)) => d.borrow_mut().pairs.push((k, v)),
+                        _ => bail!("SETITEM without dict on stack"),
+                    }
+                }
+                SETITEMS => self.handle_setitems()?,
+                APPEND => {
+                    let v = self.pop()?;
+                    match self.stack.last() {
+                        Some(Value::List(l)) => l.borrow_mut().push(v),
+                        _ => bail!("APPEND without list on stack"),
+                    }
+                }
+                APPENDS => {
+                    let items = self.drain_to_mark()?;
+                    let l = match self.stack.last() {
+                        Some(Value::List(l)) => l.clone(),
+                        _ => bail!("APPENDS without list on stack"),
+                    };
+                    let mut lref = l.borrow_mut();
+                    lref.reserve(items.len());
+                    lref.extend(items);
+                }
+
+                TUPLE => {
+                    let items = self.drain_to_mark()?;
+                    self.stack.push(Value::Tuple(items.into()));
+                }
+                TUPLE1 => {
+                    let a = self.pop()?;
+                    self.stack.push(Value::Tuple(Rc::from([a])));
+                }
+                TUPLE2 => {
+                    let b = self.pop()?;
+                    let a = self.pop()?;
+                    self.stack.push(Value::Tuple(Rc::from([a, b])));
+                }
+                TUPLE3 => {
+                    let c = self.pop()?;
+                    let b = self.pop()?;
+                    let a = self.pop()?;
+                    self.stack.push(Value::Tuple(Rc::from([a, b, c])));
+                }
+
+                MEMOIZE => {
+                    let idx = self.memo.len();
+                    self.memo_put(idx)?;
+                }
+                BINPUT => {
+                    let id = self.read_u8()? as usize;
+                    self.memo_put(id)?;
+                }
+                LONG_BINPUT => {
+                    let id = self.read_u32_le()? as usize;
+                    self.memo_put(id)?;
+                }
+                BINGET => {
+                    let id = self.read_u8()? as usize;
+                    self.memo_get(id)?;
+                }
+                LONG_BINGET => {
+                    let id = self.read_u32_le()? as usize;
+                    self.memo_get(id)?;
+                }
+
+                SHORT_BINUNICODE => {
+                    let n = self.read_u8()? as usize;
+                    let s = self.read_str(n)?;
+                    self.stack.push(Value::Str(s));
+                }
+                BINUNICODE => {
+                    let n = self.read_u32_le()? as usize;
+                    let s = self.read_str(n)?;
+                    self.stack.push(Value::Str(s));
+                }
+                BINUNICODE8 => {
+                    let n = self.read_u64_le()? as usize;
+                    let s = self.read_str(n)?;
+                    self.stack.push(Value::Str(s));
+                }
+
+                SHORT_BINBYTES => {
+                    let n = self.read_u8()? as usize;
+                    let b = self.read_n(n)?;
+                    self.stack.push(Value::Bytes(b.into()));
+                }
+                BINBYTES => {
+                    let n = self.read_u32_le()? as usize;
+                    let b = self.read_n(n)?;
+                    self.stack.push(Value::Bytes(b.into()));
+                }
+                BINBYTES8 => {
+                    let n = self.read_u64_le()? as usize;
+                    let b = self.read_n(n)?;
+                    self.stack.push(Value::Bytes(b.into()));
+                }
+
+                BININT => {
+                    let v = self.read_i32_le()?;
+                    self.stack.push(Value::Int(v as i64));
+                }
+                BININT1 => {
+                    let v = self.read_u8()? as i64;
+                    self.stack.push(Value::Int(v));
+                }
+                BININT2 => {
+                    let v = self.read_u16_le()? as i64;
+                    self.stack.push(Value::Int(v));
+                }
+                LONG1 => {
+                    let n = self.read_u8()? as usize;
+                    let bytes = self.read_n(n)?;
+                    self.stack.push(Value::Int(parse_long_le(&bytes)?));
+                }
+                LONG4 => {
+                    let n = self.read_u32_le()? as usize;
+                    let bytes = self.read_n(n)?;
+                    self.stack.push(Value::Int(parse_long_le(&bytes)?));
+                }
+
+                BINFLOAT => {
+                    let mut b = [0u8; 8];
+                    self.rdr.read_exact(&mut b).context("BINFLOAT")?;
+                    self.stack.push(Value::Float(f64::from_be_bytes(b)));
+                }
+
+                NONE_OP => self.stack.push(Value::None),
+                NEWTRUE => self.stack.push(Value::Bool(true)),
+                NEWFALSE => self.stack.push(Value::Bool(false)),
+
+                _ => bail!("unsupported pickle opcode: 0x{:02x}", op),
+            }
+        }
+    }
+
+    fn handle_setitems(&mut self) -> Result<()> {
+        let items = self.drain_to_mark()?;
+        let n_pairs = items.len() / 2;
+        let d = match self.stack.last() {
+            Some(Value::Dict(d)) => d.clone(),
+            _ => bail!("SETITEMS without dict on stack"),
+        };
+        {
+            let mut dref = d.borrow_mut();
+            dref.pairs.reserve(n_pairs);
+            let mut it = items.into_iter();
+            while let Some(k) = it.next() {
+                let v = it.next().context("SETITEMS odd item count")?;
+                dref.pairs.push((k, v));
+            }
+        }
+
+        // Try to recognize this dict as an event or annotation, extract its
+        // fields, and drop the dict to free its heap.
+        let (specialized, memo_id) = {
+            let dref = d.borrow();
+            // Borrow the pairs immutably to classify, then release before touching memo.
+            let memo_id = dref.memo_id;
+            // We need to call self.try_emit_specialized, which mutates self.
+            // To avoid simultaneous borrow, drop dref first and re-borrow inside.
+            drop(dref);
+            let dref = d.borrow();
+            // Build a temporary view; try_emit_specialized takes &[..].
+            // (Calling through self because it touches self.out / self.frame_cache.)
+            // Safe because self.stack still holds an Rc to the dict.
+            let specialized = self.try_emit_specialized(&dref.pairs);
+            (specialized, memo_id)
+        };
+
+        if specialized {
+            // Replace stack top with Consumed; drop local Rc; clear memo slot.
+            drop(d);
+            self.stack.pop();
+            self.stack.push(Value::Consumed);
+            if let Some(mid) = memo_id {
+                if (mid as usize) < self.memo.len() {
+                    self.memo[mid as usize] = Value::Consumed;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+/// Parse a little-endian, two's-complement variable-length integer.
+fn parse_long_le(bytes: &[u8]) -> Result<i64> {
+    if bytes.is_empty() {
+        return Ok(0);
+    }
+    if bytes.len() > 8 {
+        bail!(
+            "pickle LONG too large for i64 ({} bytes); add BigInt support",
+            bytes.len()
+        );
+    }
+    let mut v: i64 = 0;
+    for (i, &b) in bytes.iter().enumerate() {
+        v |= (b as i64) << (8 * i);
+    }
+    let msb = *bytes.last().unwrap();
+    if msb & 0x80 != 0 {
+        let used_bits = 8 * bytes.len();
+        if used_bits < 64 {
+            v |= -1i64 << used_bits;
+        }
+    }
+    Ok(v)
+}
+
+fn as_str(v: &Value) -> Option<&str> {
+    if let Value::Str(s) = v {
+        Some(s)
+    } else {
+        None
+    }
+}
+fn as_int(v: &Value) -> Option<i64> {
+    if let Value::Int(i) = v {
+        Some(*i)
+    } else {
+        None
+    }
+}
+fn frame_dict_lookup<'a>(d: &'a [(Value, Value)], key: &str) -> Option<&'a Value> {
+    for (k, v) in d {
+        if let Value::Str(s) = k {
+            if &**s == key {
+                return Some(v);
+            }
+        }
+    }
+    None
+}
+
+/// Build the frame-summary string identical to extract_snapshot.py's `frame_summary()`.
+fn frame_summary(frames: &[Value]) -> String {
+    if frames.is_empty() {
+        return String::new();
+    }
+    let mut parts: Vec<String> = Vec::with_capacity(frames.len());
+    for f in frames {
+        let Value::Dict(d) = f else { continue };
+        let d = d.borrow();
+        let filename = frame_dict_lookup(&d.pairs, "filename")
+            .and_then(as_str)
+            .unwrap_or("");
+        let name = frame_dict_lookup(&d.pairs, "name")
+            .and_then(as_str)
+            .unwrap_or("");
+        let line = frame_dict_lookup(&d.pairs, "line")
+            .and_then(as_int)
+            .unwrap_or(0);
+        let short = filename.rsplit('/').next().unwrap_or(filename);
+        parts.push(format!("{}:{} ({})", short, line, name));
+    }
+    parts.join(" <- ")
+}
+
+/// Convenience: read pickle from `rdr` and produce a Snapshot.
+pub fn parse_snapshot<R: Read>(rdr: R) -> Result<Snapshot> {
+    Parser::new(rdr).parse()
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn tiny_pickle() -> Vec<u8> {
+        let mut b = vec![PROTO, 4];
+        b.push(EMPTY_DICT);
+        b.push(MARK);
+        b.push(SHORT_BINUNICODE);
+        b.push(1);
+        b.extend_from_slice(b"a");
+        b.push(BININT1);
+        b.push(1);
+        b.push(SHORT_BINUNICODE);
+        b.push(1);
+        b.extend_from_slice(b"b");
+        b.push(EMPTY_LIST);
+        b.push(MARK);
+        b.push(BININT1);
+        b.push(10);
+        b.push(BININT1);
+        b.push(20);
+        b.push(APPENDS);
+        b.push(SETITEMS);
+        b.push(STOP);
+        b
+    }
+
+    #[test]
+    fn parses_tiny_dict_without_specialization() {
+        // No "action" or "stage" key, so the dict is not extracted.
+        let bytes = tiny_pickle();
+        let snap = Parser::new(Cursor::new(bytes)).parse().unwrap();
+        // No events / annotations were emitted because the dict isn't an event/annotation.
+        assert!(snap.events.is_empty());
+        assert!(snap.annotations.is_empty());
+    }
+
+    #[test]
+    fn parse_long_le_basic() {
+        assert_eq!(parse_long_le(&[]).unwrap(), 0);
+        assert_eq!(parse_long_le(&[0x01]).unwrap(), 1);
+        assert_eq!(parse_long_le(&[0xff]).unwrap(), -1);
+        assert_eq!(parse_long_le(&[0x80]).unwrap(), -128);
+        assert_eq!(parse_long_le(&[0x00, 0x01]).unwrap(), 256);
+    }
+}


### PR DESCRIPTION
## Summary

End-to-end Rust pipeline for PyTorch memory snapshots: parse the pickle natively (no Python subprocess), reconstruct baseline allocations the previous code was dropping, and add a CLI workflow to zoom into specific time windows on huge traces.

Three commits:

### 1. Native Rust pickle parser + baseline visualization (`3b5be68`)
- `src/pickle.rs`: streaming protocol-4 pickle parser specialized for PyTorch memory snapshots. Recognizes event/annotation dicts at SETITEMS time, extracts fields, drops the dict to free heap. Frame-summary cache keyed by `Rc::as_ptr` of the frames list. Walks `segments[*].blocks` to populate `live_blocks` (allocations live before recording started AND persisted through).
- `src/bin/extract_pickle.rs`: standalone CLI that emits the same JSON shape as `extract_snapshot.py` (plus a `live_blocks` field). Byte-identical output to Python on the 7.9 GB test pickle.
- `pair_alloc_free`: synthesizes baseline rects for free-without-prior-alloc events and from `live_blocks`. Marked `is_static_baseline` so `build_polygon_layout` pre-emits them as constant-offset polygons that skip the O(n·k) shift loop.
- `build_polygon_layout`: collapse all static baselines into a single block by default (`--no-collapse-static-baselines` to render individually). Quantize per-polygon `times_us` (i64 → i32 at 10 µs resolution relative to trace start) and `offsets` (f64 → u32 in KiB). Parallel f64-bytes tracker during the build keeps running totals exact so quantization doesn't compound across shifts.
- Optional `dhat` heap profiling via the `heap-profile` cargo feature.

### 2. Time-window CLI flags (`d73b621`)
- `--time-start-sec` / `--time-end-sec`: filter events to a window (seconds from trace start). Annotations are clipped to the same window. `live_blocks` are dropped (replaced in commit 3).
- Enables the two-pass workflow: load with `--max-entries 100000` to see the whole trace, then relaunch with a narrow window plus a higher `--max-entries` to render every rect individually.

### 3. Display-origin anchoring + live-at-window-start reconstruction (`b891098`)
- `PolygonLayout` gains `display_origin_us` (the trace's first event time, captured *before* filtering). All display-side time-relative calculations use it: a `--time-start-sec 540` window now shows "540 s" at the leftmost tick instead of "0 s".
- When a window is active, pre-walk events before `lo` to find allocations live at window start. Feed them into `live_blocks` so they render via the segments-style collapsed-baseline path. Without this the windowed view's left edge starts empty even though tens of GB of long-lived allocations are still present.

## Why this matters

Before: the visualizer for PyTorch memory snapshots shelled out to `python extract_snapshot.py`, which used ~30 GB RAM on a 7.9 GB pickle (CPython object overhead × 31M events). For the largest profiles (`max number of elements` truncated), the chart didn't show baseline memory at all.

After: native Rust extraction in ~5 minutes (vs Python's ~11) and a fraction of the peak RSS (22 GB vs 33 GB). Baselines (~42 GB on the truncated sam-604 profile) now render correctly. The full sam-609 (31M events) is now interactively viewable on a 96 GB machine via `--max-entries 100000`, and any time window can be zoomed-into for full individual-rect detail.

## Caveats / known limits

- `build_polygon_layout` is still O(n × working_set) in polygon-history entries. For sam-609 *without* `--max-entries`, the layout's peak-live heap exceeds physical RAM (verified by dhat: 484 GB for sam-609 half). The new flags work around this rather than solve it.
- `live_blocks` derived from segments only apply to unfiltered views (they describe end-of-snapshot state). Windowed views compute their own live set via the pre-walk.

## Test plan

- [x] `cargo test --bin desktop-memory-viz` (6 unit tests: pickle parser, pair_alloc_free baseline cases incl. spurious-baseline regression, live_blocks-to-rects)
- [x] `extract_pickle` byte-identical to `extract_snapshot.py` on 7.9 GB sam-609 (verified via `cmp`)
- [x] Load sam-604 (1M events, truncated profile) — shows full ~42 GB baseline at chart start
- [x] Load sam-609 (31M events) with `--max-entries 100000` — loads in ~4 s, 5 GB RSS
- [x] Load sam-609 windowed `--time-start-sec 540 --time-end-sec 600` — shows ~50 GB baseline carried over from before window
- [x] Compare numerical totals against the web profiler for one or two known snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)